### PR TITLE
feat: adjust 2 typescript rules

### DIFF
--- a/packages/eslint-plugin/lib/config/rules/typescript.js
+++ b/packages/eslint-plugin/lib/config/rules/typescript.js
@@ -207,7 +207,7 @@ module.exports = {
   // Sets preference level for triple slash directives versus ES6-style import declarations
   '@typescript-eslint/triple-slash-reference': [
     'error',
-    { path: 'never', types: 'never', lib: 'never' },
+    { path: 'never', types: 'always', lib: 'never' },
   ],
   // Requires type annotations to exist
   '@typescript-eslint/typedef': 'off',
@@ -247,10 +247,11 @@ module.exports = {
   // Requires that private members are marked as readonly if they're never modified outside of the constructor
   '@typescript-eslint/prefer-readonly': 'off',
   // This rule enforces a consistent way to define records.
-  '@typescript-eslint/consistent-indexed-object-style': [
-    'error',
-    'index-signature',
-  ],
+  // '@typescript-eslint/consistent-indexed-object-style': [
+  //   'error',
+  //   'index-signature',
+  // ],
+  '@typescript-eslint/consistent-indexed-object-style': 'off',
   // Disallows unnecessary constraints on generic types
   '@typescript-eslint/no-unnecessary-type-constraint': 'error',
 


### PR DESCRIPTION
## Description

1. Change option `types` of @typescript-eslint/triple-slash-reference from `never` to `always`
2. Turn off `@typescript-eslint/consistent-indexed-object-style`

## Type of change

<!--
Remember to indicate the affected package(s), as well as the type of change for each package.
-->

- [ ] <!--Package Name--> Patch: Bug (non-breaking change which fixes an issue)
- [x] <!--Package Name--> Minor: New feature (non-breaking change which adds functionality)
- [ ] <!--Package Name--> Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above (Documentation fix and Test update does not need a changelog as we do not publish a new version for these changes)
